### PR TITLE
Heroku上でGoogleログイン時にrollbackが起こるためgoogleの画像はsessionに格納して使用

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,7 +7,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   # common callback method
   def callback_for(provider)
-    @user = User.from_omniauth(request.env["omniauth.auth"], "OmniauthCallbacksController")
+    auth = request.env["omniauth.auth"]
+    @user = User.from_omniauth(auth, "OmniauthCallbacksController")
+    session[:google_image] = auth.info.image
+
     if @user.persisted?
       sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
       set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,6 @@ class User < ApplicationRecord
          :omniauthable, omniauth_providers: %i[google_oauth2] #複数追加したいとき -> %i[facebook twitter google_oauth2]
 
   validate :password_complexity
-  validates :image, presence: true
 
   mount_uploader :image, ImageUploader
 
@@ -20,8 +19,7 @@ class User < ApplicationRecord
   # omniauthのコールバック時に呼ばれるメソッド
   def self.from_omniauth(auth, controller_name)
     @controller_name = controller_name
-    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-      user.google_image = auth.info.image
+    where(provider: auth.provider, uid: auth.uid).first_or_create! do |user|
       user.email = auth.info.email
       user.password = Devise.friendly_token[8,20]
     end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -13,7 +13,7 @@
 <% if @user.image.present? %>
   <img src="<%= @user.image %>" class = "icon_image">
 <% else %>
-  <img src="<%= @user.google_image %>" class = "icon_image">
+  <img src="<%= session[:google_image] %>" class = "icon_image">
 <% end %>
 
 <h2>イベント</h2>

--- a/db/migrate/20200722094734_add_googleimage_to_users.rb
+++ b/db/migrate/20200722094734_add_googleimage_to_users.rb
@@ -1,5 +1,0 @@
-class AddGoogleimageToUsers < ActiveRecord::Migration[6.0]
-  def change
-    add_column :users, :google_image, :string
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_22_094734) do
+ActiveRecord::Schema.define(version: 2020_07_22_091250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,7 +67,6 @@ ActiveRecord::Schema.define(version: 2020_07_22_094734) do
     t.string "provider"
     t.string "uid"
     t.string "image"
-    t.string "google_image"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
- google_imageのマイグレーション ファイル削除、テーブルからもgoogle_imageのカラム は削除
- コントローラ側でgoogle_imageに関するsessionの作成