### PR TITLE
active adminの画面で扱えるイベントリンクを追加 #67

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -1,0 +1,4 @@
+ActiveAdmin.register Event do
+  permit_params :name, :event_date, :details
+
+end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -45,6 +45,12 @@ ja:
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
         updated_at: 更新日
+      event:
+        name: イベント名
+        event_date: 開催日
+        details: 詳細
+        created_at: 作成日
+        updated_at: 更新日
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,14 +1,18 @@
 # Menuのダミーデータ
 # Topicのダミーデータ
 # Userのダミーデータ
+# Eventのダミーデータ
+
 menu_params = []
 topic_params = []
 user_params = []
+event_params = []
 
 # 既存のデータを削除
 Menu.delete_all
 Topic.delete_all
 User.delete_all
+Event.delete_all
 
 100.times do
   # Menuのダミーデータ作成
@@ -31,9 +35,17 @@ User.delete_all
   email = Faker::Internet.unique.email
 
   user_params << { nickname: nickname, image: image, password: password, email: email }
+
+  # Eventのダミーデータ
+  name = Faker::Book.title
+  event_date = Faker::Time.backward(days: 5, period: :morning, format: :short)
+  details = Faker::Types.rb_string
+
+  event_params << { name: name, event_date: event_date, details: details }
 end
 
 # データ登録
 Menu.create!(menu_params)
 Topic.create!(topic_params)
 User.create!(user_params)
+Event.create!(event_params)


### PR DESCRIPTION
【実装内容】
- イベントのダミーデータをseed.rbに記述
- 管理者画面のナビバーへ、イベントデータのリンクを追加
- 新規登録、更新、削除ができるようにする

【参考資料】
https://github.com/faker-ruby/faker/blob/master/README.md