### PR TITLE
イベントの表示は追加した内容が上にくるようにする #71

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
   def index
-    @events = Event.all
+    @events = Event.all.reverse
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,5 @@
 class EventsController < ApplicationController
   def index
-    @events = Event.all.reverse
+    @events = Event.all.order(created_at: "DESC")
   end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -3,7 +3,6 @@ class HomesController < ApplicationController
     @topics = Topic.first(5)
     @users = User.first(5)
     @menus = Menu.first(5)
-    reverse_event = Event.all.reverse
-    @events = reverse_event.first(5)
+    @events = Event.last(5).reverse
   end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -3,6 +3,6 @@ class HomesController < ApplicationController
     @topics = Topic.first(6)
     @users = User.first(12)
     @menus = Menu.first(6)
-    @events = Event.last(6).reverse
+    @events = Event.order(created_at: "DESC").first(6)
   end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -3,6 +3,7 @@ class HomesController < ApplicationController
     @topics = Topic.first(5)
     @users = User.first(5)
     @menus = Menu.first(5)
-    @events = Event.first(5)
+    reverse_event = Event.all.reverse
+    @events = reverse_event.first(5)
   end
 end

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -5,6 +5,7 @@ ja:
       comment: コメント
       user: ユーザ
       topic: トピック
+      event: イベント
     attributes:
       admin_user:
         email: メールアドレス


### PR DESCRIPTION
【実装内容】

- 管理者画面でイベントラベルの日本語化
- 「直近5件をhomeに表示」と「イベント一覧」

（新たに追加されたイベントがページの上にくるように並べました）
