### PR TITLE
一覧ページのフリーランスを横並びで６つ表示

### DIFF
--- a/app/assets/stylesheets/_users.scss
+++ b/app/assets/stylesheets/_users.scss
@@ -13,3 +13,24 @@
     }
   }
 }
+#users {
+  // ユーザーのカード定義
+  .user .card{
+    border: solid 1px black;
+    margin: 10px;
+    width: 130px;
+    height: 160px;
+  }
+  .user img{
+    width: 128px;
+    height: 110px;
+  }
+  .user .card-body p{
+    font-size: 10px;
+    word-break: normal;
+  }
+
+  .users-card {
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import "bootstrap/scss/bootstrap";
 @import "homes";
+@import "users";
 
 /*
 *= require_tree .

--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -11,6 +11,7 @@
 
   // ユーザーのカード定義
   .user .card{
+    border: solid 1px black;
     margin: 10px;
     width: 130px;
     height: 160px;
@@ -21,6 +22,7 @@
   }
   .user .card-body p{
     font-size: 10px;
+    word-break: normal;
   }
 
   .users-card {

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -16,7 +16,13 @@
   <%= link_to  "もっとみる", menus_path %>
 
   <h2 class="text-center">フリーランス</h2>
-  <%= render "users/user" %>
+  <div class="user">
+    <div class="container">
+      <div class="row">
+        <%= render @users %>
+      </div>
+    </div>
+  </div>
   <div class="text-center">
     <%= link_to "もっとみる", users_path %>
   </div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -11,12 +11,12 @@
     <%= link_to  "もっとみる", events_path %>
   </div>
 
-  <h2>メニュー</h2>
+  <h2 class="text-center">メニュー</h2>
   <%= render @menus %>
   <%= link_to  "もっとみる", menus_path %>
 
   <h2 class="text-center">フリーランス</h2>
-  <%= render @users %>
+  <%= render "users/user" %>
   <div class="text-center">
     <%= link_to "もっとみる", users_path %>
   </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,5 +1,6 @@
 <div class="user">
   <div class="row">
+    <% @users.each do |user| %>
       <div class="users-card col-lg-2 col-md-12">
         <div class="card">
           <%= image_tag "#{user.image}" ,class:"card-img-top" %>
@@ -8,5 +9,6 @@
           </div>
         </div>
       </div>
+      <% end %>
   </div>
 </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,14 +1,8 @@
-<div class="user">
-  <div class="row">
-    <% @users.each do |user| %>
-      <div class="users-card col-lg-2 col-md-12">
-        <div class="card">
-          <%= image_tag "#{user.image}" ,class:"card-img-top" %>
-          <div class="card-body">
-            <p class="card-text"><%= user.nickname %></p>
-          </div>
-        </div>
-      </div>
-      <% end %>
+<div class="users-card col-lg-2 col-md-12">
+  <div class="card">
+    <%= image_tag "#{user.image}" ,class:"card-img-top" %>
+    <div class="card-body">
+      <p class="card-text"><%= user.nickname %></p>
+    </div>
   </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,4 +1,10 @@
 <section id="homes">
   <h2>フリーランス一覧</h2>
-  <%= render 'users/user' %>
+  <div class="user">
+    <div class="container">
+      <div class="row">
+        <%= render @users %>
+      </div>
+    </div>
+  </div>
 </section>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,4 +1,4 @@
-<section id="homes">
+<section id="users">
   <h2>フリーランス一覧</h2>
   <div class="user">
     <div class="container">

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,2 +1,4 @@
-<h2>フリーランス一覧</h2>
-<%= render @users %>
+<section id="homes">
+  <h2>フリーランス一覧</h2>
+  <%= render 'users/user' %>
+</section>


### PR DESCRIPTION
**実装内容**
- フリーランスのカード表示を横並びで６つ表示した
- メニューが中央に寄っていなかったので中央寄せした
- 「もっとみる」での詳細ページでもCSSが適用されるように変更
- デザインを調整