### PR TITLE
skillsテーブルとusersテーブルの関連付け

### DIFF
--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -1,0 +1,2 @@
+class SkillsController < ApplicationController
+end

--- a/app/controllers/user_skills_controller.rb
+++ b/app/controllers/user_skills_controller.rb
@@ -1,0 +1,2 @@
+class UserSkillsController < ApplicationController
+end

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,0 +1,4 @@
+class Skill < ApplicationRecord
+  has_many :users, through: :user_skills
+  has_many :user_skills
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,4 +23,7 @@ class User < ApplicationRecord
       user.password = Devise.friendly_token[8,20]
     end
   end
+
+  has_many :skills, through: :user_skills
+  has_many :user_skills
 end

--- a/app/models/user_skill.rb
+++ b/app/models/user_skill.rb
@@ -1,0 +1,4 @@
+class UserSkill < ApplicationRecord
+  belongs_to :user
+  belongs_to :skill
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   root to: 'homes#index'
-  resources :users
+  resources :users 
   resources :topics, only: :index
   resources :menus, only: :index
   resources :events, only: :index
+  resources :skills 
 end

--- a/db/migrate/20200805085525_create_skills.rb
+++ b/db/migrate/20200805085525_create_skills.rb
@@ -1,0 +1,10 @@
+class CreateSkills < ActiveRecord::Migration[6.0]
+  def change
+    create_table :skills do |t|
+      t.string :skill
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200805090846_create_user_skills.rb
+++ b/db/migrate/20200805090846_create_user_skills.rb
@@ -1,0 +1,10 @@
+class CreateUserSkills < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_skills do |t|
+      t.integer :user_id
+      t.integer :skill_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_31_005847) do
+ActiveRecord::Schema.define(version: 2020_08_05_090846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,9 +57,23 @@ ActiveRecord::Schema.define(version: 2020_07_31_005847) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "skills", force: :cascade do |t|
+    t.string "skill"
+    t.integer "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "topics", force: :cascade do |t|
     t.string "title"
     t.text "contents"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_skills", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "skill_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -76,7 +90,6 @@ ActiveRecord::Schema.define(version: 2020_07_31_005847) do
     t.string "uid"
     t.string "image"
     t.string "nickname"
-    t.string "google_image"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
【実装内容】
・skillsテーブルの作成(カラムはskill, user_id)
・中間テーブルuser_skillsの作成(カラムはuser_id, skill_id)
・モデルに関連付けの記述