### PR TITLE
イベントの表示をカードスタイルに変更

### DIFF
--- a/app/assets/stylesheets/_events.scss
+++ b/app/assets/stylesheets/_events.scss
@@ -1,0 +1,16 @@
+#events {
+  // ユーザーのカード定義
+  .event .card{
+    border: solid 1px black;
+    margin: 10px;
+    width: 130px;
+    height: 290px;
+  }
+  .event .card-body p{
+    font-size: 12px;
+    word-break: normal;
+  }
+  .events-card {
+    text-align: center;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 @import "bootstrap/scss/bootstrap";
 @import "homes";
 @import "users";
+@import "events";
 
 /*
 *= require_tree .

--- a/app/assets/stylesheets/homes.scss
+++ b/app/assets/stylesheets/homes.scss
@@ -28,4 +28,19 @@
   .users-card {
     text-align: center;
   }
+
+// イベントのカード定義
+  .event .card{
+    border: solid 1px black;
+    margin: 10px;
+    width: 130px;
+    height: 290px;
+  }
+  .event .card-body p{
+    font-size: 12px;
+    word-break: normal;
+  }
+  .events-card {
+    text-align: center;
+  }
 }

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,5 +1,9 @@
-  <p>
-    <%= event.name %>
-    <%= event.event_date %>
-    <%= event.details %>
-  </p>
+  <div class="events-card col-lg-2 col-md-12">
+    <div class="card">
+      <p class="card-text"><%= event.name %></p>
+      <div class="card-body">
+        <p class="card-text"><%= event.event_date %></p>
+        <p class="card-text"><%= event.details %></p>
+      </div>
+    </div>
+  </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,2 +1,10 @@
-<h2>イベント一覧</h2>
-<%= render @events %>
+<section id="events">
+  <h2>イベント一覧</h2>
+  <div class="event">
+    <div class="container">
+      <div class="row">
+        <%= render @events %>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -6,7 +6,13 @@
   </div>
 
   <h2 class="text-center">イベント</h2>
-  <%= render @events %>
+  <div class="event">
+    <div class="container">
+      <div class="row">
+        <%= render @events %>
+      </div>
+    </div>
+  </div>
   <div class="text-center">
     <%= link_to  "もっとみる", events_path %>
   </div>


### PR DESCRIPTION
**実装内容**
- イベントをカードスタイルを実装
- 「もっとみる」の一覧ページでカードスタイルを実装
- CSSでデザインを調整